### PR TITLE
Modified Submission Makefile for Uni Seminar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,93 @@
+# Use this file at your own risk.
+# Always ensure that the required files are actually put into the archive,
+# and that no additional files are archived.
+# You can use the zipinfo command to check the file structure of an existing archive.
+
+# --- ADJUST BELOW ----------------
+
+# Number of people: set to 1, 2 or 3 (how many zips to create)
+PEOPLE ?= 2
+USERNAME_PERSON_1 = csbaXXXX
+USERNAME_PERSON_2 = csbbXXXX
+USERNAME_PERSON_3 = csbcXXXX
+EXERCISE = 04
+
+# Data for group.txt. Only relevant if PEOPLE is not 1.
+PERSON_1 = Max Mustermann
+PERSON_2 = Gordon Freeman
+PERSON_3 = Alyx Vance
+MAT_NUM_1 = 12345678
+MAT_NUM_2 = 87654321
+MAT_NUM_3 = 98765432
+
+# ---------------------------------
+
+# This excludes some common directories automatically.
+# Also ignores all binaries and README.md.
+EXCLUDE_PATTERNS = "**.vscode/*" "**.idea/*" "**__MACOSX/*" "**.DS_Store/*" "**.dSYM/*" "**/*.o" "**/a.out" "README.md"
+
+ARCHIVE_PERSON_1 = "./exc$(EXERCISE)_$(USERNAME_PERSON_1).zip"
+ARCHIVE_PERSON_2 = "./exc$(EXERCISE)_$(USERNAME_PERSON_2).zip"
+ARCHIVE_PERSON_3 = "./exc$(EXERCISE)_$(USERNAME_PERSON_3).zip"
+
+# --- TARGETS ---
+
+.PHONY: all
+all: prepare zip
+
+# prepare: execute clean, group, format, and setperms in order.
+.PHONY: prepare
+prepare: clean group format setperms
+
+.PHONY: clean
+clean:
+	@echo "Cleaning task folders in exercise$(EXERCISE)..."
+	@for dir in ./exercise$(EXERCISE)/task_*; do \
+		if [ -d "$$dir" ]; then \
+			-$(MAKE) -C "$$dir" clean || echo "Warning: no clean target in $$dir"; \
+		fi; \
+	done
+	@rm -f exercise$(EXERCISE)/group.txt
+
+.PHONY: group
+group:
+ifeq ($(strip $(PEOPLE)),1)
+	@echo "Single submission detected: group.txt will not be created."
+else
+	@echo "Creating group.txt in exercise$(EXERCISE)..."
+	@echo "$(MAT_NUM_1) $(PERSON_1)" > exercise$(EXERCISE)/group.txt
+ifneq ($(filter 2 3,$(strip $(PEOPLE))),)
+	@echo "$(MAT_NUM_2) $(PERSON_2)" >> exercise$(EXERCISE)/group.txt
+endif
+ifneq ($(filter 3,$(strip $(PEOPLE))),)
+	@echo "$(MAT_NUM_3) $(PERSON_3)" >> exercise$(EXERCISE)/group.txt
+endif
+endif
+
+.PHONY: format
+format:
+	@echo "Formatting all .c files in exercise$(EXERCISE)..."
+	@find exercise$(EXERCISE) -type f -name "*.c" -exec clang-format -i {} \;
+
+.PHONY: setperms
+setperms:
+	@echo "Setting world-read permissions for all files in exercise$(EXERCISE)..."
+	@find exercise$(EXERCISE) -type f -exec chmod a+r {} \;
+
+.PHONY: zip
+zip: prepare
+	@mkdir -p submission
+	$(RM) ./submission/$(ARCHIVE_PERSON_1)
+ifeq ($(strip $(PEOPLE)),1)
+	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_1) . --exclude $(EXCLUDE_PATTERNS))
+else ifeq ($(strip $(PEOPLE)),2)
+	$(RM) ./submission/$(ARCHIVE_PERSON_2)
+	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_1) . --exclude $(EXCLUDE_PATTERNS))
+	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_2) . --exclude $(EXCLUDE_PATTERNS))
+else ifeq ($(strip $(PEOPLE)),3)
+	$(RM) ./submission/$(ARCHIVE_PERSON_2)
+	$(RM) ./submission/$(ARCHIVE_PERSON_3)
+	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_1) . --exclude $(EXCLUDE_PATTERNS))
+	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_2) . --exclude $(EXCLUDE_PATTERNS))
+	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_3) . --exclude $(EXCLUDE_PATTERNS))
+endif

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ USERNAMES = csbaXXXX csbbXXXX csbcXXXX
 # Names and matriculation numbers for group.txt (only used if PEOPLE > 1)
 # Underscores in PERSONS are replaced by spaces in the output.
 PERSONS = Max_Mustermann Gordon_Freeman Alyx_Vance
-MAT_NUMS  = 12345678 87654321 98765432
+MAT_NUMS = 12345678 87654321 98765432
 
 # Exercise number / folder
 EXERCISE = 04

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PERSONS   = Max_Mustermann Gordon_Freeman Alyx_Vance
 MAT_NUMS  = 12345678 87654321 98765432
 
 # Exercise number / folder
-EXERCISE  = 04
+EXERCISE = 04
 
 # ---------------------------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,16 @@
 # and that no additional files are archived.
 # You can use the zipinfo command to check the file structure of an existing archive.
 
-# --- ADJUST BELOW ----------------
+# --- ADJUST BELOW ----------------------------------------------------------------------------------
 
 # Number of people: set to 1, 2 or 3 (how many zips to create)
-PEOPLE ?= 2
+PEOPLE ?= 3
 USERNAME_PERSON_1 = csbaXXXX
 USERNAME_PERSON_2 = csbbXXXX
 USERNAME_PERSON_3 = csbcXXXX
-EXERCISE = 04
+EXERCISE = 05
 
-# Data for group.txt. Only relevant if PEOPLE is not 1.
+# Data for group.txt. Only relevant if PEOPLE is greater than 1.
 PERSON_1 = Max Mustermann
 PERSON_2 = Gordon Freeman
 PERSON_3 = Alyx Vance
@@ -20,25 +20,34 @@ MAT_NUM_1 = 12345678
 MAT_NUM_2 = 87654321
 MAT_NUM_3 = 98765432
 
-# ---------------------------------
+# ---------------------------------------------------------------------------------------------------
 
 # This excludes some common directories automatically.
 # Also ignores all binaries and README.md.
 EXCLUDE_PATTERNS = "**.vscode/*" "**.idea/*" "**__MACOSX/*" "**.DS_Store/*" "**.dSYM/*" "**/*.o" "**/a.out" "README.md"
 
-ARCHIVE_PERSON_1 = "./exc$(EXERCISE)_$(USERNAME_PERSON_1).zip"
-ARCHIVE_PERSON_2 = "./exc$(EXERCISE)_$(USERNAME_PERSON_2).zip"
-ARCHIVE_PERSON_3 = "./exc$(EXERCISE)_$(USERNAME_PERSON_3).zip"
+ARCHIVE_PERSON_1 = ./exc$(EXERCISE)_$(USERNAME_PERSON_1).zip
+ARCHIVE_PERSON_2 = ./exc$(EXERCISE)_$(USERNAME_PERSON_2).zip
+ARCHIVE_PERSON_3 = ./exc$(EXERCISE)_$(USERNAME_PERSON_3).zip
+
+# Define all possible archives and select only the first $(PEOPLE) ones.
+ARCHIVES := $(ARCHIVE_PERSON_1) $(ARCHIVE_PERSON_2) $(ARCHIVE_PERSON_3)
+SUBARCHIVES := $(wordlist 1, $(PEOPLE), $(ARCHIVES))
 
 # --- TARGETS ---
 
 .PHONY: all
 all: prepare zip
 
-# prepare: execute clean, group, format, and setperms in order.
+# prepare: execute clean, group, format, and setperms in order
 .PHONY: prepare
-prepare: clean group format setperms
+prepare:
+	@for target in clean group format setperms; do \
+		echo "Executing $$target..."; \
+		$(MAKE) $$target; \
+	done
 
+#  cleans all task subdirectories and removes any existing group.txt file
 .PHONY: clean
 clean:
 	@echo "Cleaning task folders in exercise$(EXERCISE)..."
@@ -49,45 +58,56 @@ clean:
 	done
 	@rm -f exercise$(EXERCISE)/group.txt
 
+# creates the group.txt file dynamically (only if PEOPLE > 1)
+# by looping over the number of people and appending the corresponding matriculation number and full name
 .PHONY: group
 group:
 ifeq ($(strip $(PEOPLE)),1)
 	@echo "Single submission detected: group.txt will not be created."
 else
 	@echo "Creating group.txt in exercise$(EXERCISE)..."
-	@echo "$(MAT_NUM_1) $(PERSON_1)" > exercise$(EXERCISE)/group.txt
-ifneq ($(filter 2 3,$(strip $(PEOPLE))),)
-	@echo "$(MAT_NUM_2) $(PERSON_2)" >> exercise$(EXERCISE)/group.txt
-endif
-ifneq ($(filter 3,$(strip $(PEOPLE))),)
-	@echo "$(MAT_NUM_3) $(PERSON_3)" >> exercise$(EXERCISE)/group.txt
-endif
+	@rm -f exercise$(EXERCISE)/group.txt
+	@for i in 1 2 3; do \
+	    if [ $$i -le $(PEOPLE) ]; then \
+	        case $$i in \
+	            1) echo "$(MAT_NUM_1) $(PERSON_1)" >> exercise$(EXERCISE)/group.txt ;; \
+	            2) echo "$(MAT_NUM_2) $(PERSON_2)" >> exercise$(EXERCISE)/group.txt ;; \
+	            3) echo "$(MAT_NUM_3) $(PERSON_3)" >> exercise$(EXERCISE)/group.txt ;; \
+	        esac; \
+	    fi; \
+	done
 endif
 
+# Uses clang-format to format all .c files
+# It first checks if clang-format is installed
+# if not, it skips formatting
 .PHONY: format
 format:
 	@echo "Formatting all .c files in exercise$(EXERCISE)..."
-	@find exercise$(EXERCISE) -type f -name "*.c" -exec clang-format -i {} \;
+	@if command -v clang-format >/dev/null 2>&1; then \
+		find exercise$(EXERCISE) -type f -name "*.c" -exec clang-format -i {} \; ; \
+	else \
+		echo "clang-format not found, skipping formatting."; \
+	fi
 
+# Sets world-readable permissions on all files in the exercise folder
 .PHONY: setperms
 setperms:
 	@echo "Setting world-read permissions for all files in exercise$(EXERCISE)..."
 	@find exercise$(EXERCISE) -type f -exec chmod a+r {} \;
+# chmod a+r
+# a... all users
+# +... add
+# r... read
 
+
+# Creates zip archives for submission.
+# Dynamically iterates over the first $(PEOPLE) archives from our list
 .PHONY: zip
 zip: prepare
 	@mkdir -p submission
-	$(RM) ./submission/$(ARCHIVE_PERSON_1)
-ifeq ($(strip $(PEOPLE)),1)
-	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_1) . --exclude $(EXCLUDE_PATTERNS))
-else ifeq ($(strip $(PEOPLE)),2)
-	$(RM) ./submission/$(ARCHIVE_PERSON_2)
-	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_1) . --exclude $(EXCLUDE_PATTERNS))
-	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_2) . --exclude $(EXCLUDE_PATTERNS))
-else ifeq ($(strip $(PEOPLE)),3)
-	$(RM) ./submission/$(ARCHIVE_PERSON_2)
-	$(RM) ./submission/$(ARCHIVE_PERSON_3)
-	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_1) . --exclude $(EXCLUDE_PATTERNS))
-	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_2) . --exclude $(EXCLUDE_PATTERNS))
-	(cd exercise$(EXERCISE) && zip -r ../submission/$(ARCHIVE_PERSON_3) . --exclude $(EXCLUDE_PATTERNS))
-endif
+	$(RM) $(foreach a,$(ARCHIVES),./submission/$(a))
+	@echo "Creating zip archives for $(PEOPLE) people..."
+	$(foreach archive,$(SUBARCHIVES), (cd exercise$(EXERCISE) && zip -r ../submission/$(archive) . --exclude $(EXCLUDE_PATTERNS));)
+
+.PHONY: all clean group format setperms zip

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ USERNAMES = csbaXXXX csbbXXXX csbcXXXX
 
 # Names and matriculation numbers for group.txt (only used if PEOPLE > 1)
 # Underscores in PERSONS are replaced by spaces in the output.
-PERSONS   = Max_Mustermann Gordon_Freeman Alyx_Vance
+PERSONS = Max_Mustermann Gordon_Freeman Alyx_Vance
 MAT_NUMS  = 12345678 87654321 98765432
 
 # Exercise number / folder


### PR DESCRIPTION
I created an improved version of the submission Makefile used for our uni seminar and thought i may share it. The key improvements are as follows:

- **Code formatting:**  
  Formats all *.c files via the provided clang file.

- **Automatic `group.txt` Creation:**  
  The Makefile now automatically creates a `group.txt` file in the exercise folder, depending on the `PEOPLE` variable (see below). This file is then included in the submission zip.

- **Submission Folder Creation:**  
The Makefile checks if a `submission` folder exists and creates it if necessary, ensuring that the zip files are placed in a unified location.

- **Conditional Archive Creation:**  
Depending on the `PEOPLE` variable, the Makefile creates either a single archive (if `PEOPLE=1`) or two archives (if `PEOPLE=2`), which allows for both individual and group submissions.

- **World-Readable Permissions:**  
A new target sets all files in the exercise folder to be world-readable (`chmod a+r`), ensuring that third parties can read the files if needed.

## How to Use
- Run `make all` to execute the complete workflow (clean, group file creation, formatting, permission setting, and zip archive creation).
- Use the `PEOPLE` variable to control the number of archives:
- `make PEOPLE=1 all` creates only the archive for Person 1.
- `make PEOPLE=2 all` (or simply `make all`, as the default is 2) creates both archives.
